### PR TITLE
Tweaks for running against Vinays mercurial Python 3 work

### DIFF
--- a/djangobench/main.py
+++ b/djangobench/main.py
@@ -16,7 +16,7 @@ __version__ = '0.9'
 
 DEFAULT_BENCMARK_DIR = Path(__file__).parent.child('benchmarks').absolute()
 
-def run_benchmarks(control, experiment, benchmark_dir, benchmarks, trials, vcs=None, record_dir=None, profile_dir=None):
+def run_benchmarks(control, experiment, benchmark_dir, benchmarks, trials, vcs=None, record_dir=None, profile_dir=None, continue_on_errror=False):
     if benchmarks:
         print "Running benchmarks: %s" % " ".join(benchmarks)
     else:
@@ -63,6 +63,11 @@ def run_benchmarks(control, experiment, benchmark_dir, benchmarks, trials, vcs=N
             except SkipBenchmark, reason:
                 print "Skipped: %s\n" % reason
                 continue
+            except RuntimeError, error:
+                if continue_on_errror:
+                    print "Failed: %s\n" % error
+                    continue
+                raise
 
             options = argparse.Namespace(
                 track_memory = False,
@@ -286,6 +291,12 @@ def main():
         metavar = 'PATH',
         help = 'Directory to record profiling statistics for the control and experimental run of each benchmark'
     )
+    parser.add_argument(
+        '--continue-on-error',
+        dest = 'continue_on_errror',
+        action = 'store_true',
+        help = 'Continue with the remaining benchmarks if any fail',
+    )
 
     args = parser.parse_args()
     run_benchmarks(
@@ -296,7 +307,8 @@ def main():
         trials = args.trials,
         vcs = args.vcs,
         record_dir = args.record,
-        profile_dir = args.profile_dir
+        profile_dir = args.profile_dir,
+        continue_on_errror = args.continue_on_errror
     )
 
 if __name__ == '__main__':


### PR DESCRIPTION
I made these changes when working on http://dgauge.ep.io/ ( https://github.com/d0ugal/django-gauge ) - a fun side project that borrows from your codes in https://github.com/jacobian/django-dev-dashboard :) The changes are currently being used in the live site.

The first commit adds support for mercurial repositories. The second adds a flag to continue on errors, this is to work around a currently failing benchmark when running the Python 3 port (on Python 2.6).

If its easier, i can submit a pull request for each of these - but they are fairly small changes so it may not be needed (if you consider them a good idea to merge.)
