### PR TITLE
Python 3 compatibility

### DIFF
--- a/djangobench/base_settings.py
+++ b/djangobench/base_settings.py
@@ -1,3 +1,5 @@
+ALLOWED_HOSTS = ['*']
+
 DATABASE_ENGINE = 'sqlite3'
 DATABASE_NAME = ':memory:'
 

--- a/djangobench/benchmarks/default_middleware/benchmark.py
+++ b/djangobench/benchmarks/default_middleware/benchmark.py
@@ -1,5 +1,3 @@
-from time import time
-
 from django.test.client import Client, FakePayload
 from django.conf import global_settings
 from django.conf import settings
@@ -7,6 +5,7 @@ from django.core.handlers.wsgi import WSGIRequest
 from django.core.handlers.wsgi import WSGIHandler
 
 from djangobench.utils import run_comparison_benchmark
+
 
 class RequestFactory(Client):
     """
@@ -33,7 +32,7 @@ class RequestFactory(Client):
         has created it.
         """
         environ = {
-            'HTTP_COOKIE': self.cookies,
+            'HTTP_COOKIE': self.cookies.output(header='', sep='; '),
             'PATH_INFO': '/',
             'QUERY_STRING': '',
             'REQUEST_METHOD': 'GET',
@@ -48,6 +47,7 @@ class RequestFactory(Client):
 
         return WSGIRequest(environ)
 
+
 def setup():
     global req_factory, handler_default_middleware, handler_no_middleware
     req_factory = RequestFactory()
@@ -60,6 +60,7 @@ def setup():
     handler_no_middleware = WSGIHandler()
     handler_no_middleware.load_middleware()
 
+
 def benchmark_request(middleware_classes):
     settings.MIDDLEWARE_CLASSES = middleware_classes
     req_factory = RequestFactory()
@@ -67,20 +68,23 @@ def benchmark_request(middleware_classes):
     handler.load_middleware()
     handler.get_response(req_factory.get('/'))
 
+
 def benchmark_default_middleware():
     global req_factory, handler_default_middleware
     handler_default_middleware.get_response(req_factory.get('/'))
+
 
 def benchmark_no_middleware():
     global req_factory, handler_no_middleware
     handler_no_middleware.get_response(req_factory.get('/'))
 
+
 run_comparison_benchmark(
     benchmark_default_middleware,
     benchmark_no_middleware, 
-    setup = setup,
-    syncdb = False,
-    meta = {
+    setup=setup,
+    syncdb=False,
+    meta={
         'description': 'Request/response overhead added by the default middleware.',
     }
 )

--- a/djangobench/benchmarks/l10n_render/settings.py
+++ b/djangobench/benchmarks/l10n_render/settings.py
@@ -1,8 +1,10 @@
-from unipath import FSPath as Path
+import os
+
 from djangobench.base_settings import *
 
 USE_I18N = False
 USE_L10N = True
-
-TEMPLATE_DIRS = [Path(__file__).parent.child('templates').absolute()]
+TEMPLATE_DIRS = (
+    os.path.abspath(os.path.join(os.path.dirname(__file__), 'templates')),
+)
 INSTALLED_APPS = ['l10n_render']

--- a/djangobench/benchmarks/query_exists/benchmark.py
+++ b/djangobench/benchmarks/query_exists/benchmark.py
@@ -1,6 +1,7 @@
 from djangobench.utils import run_benchmark
 from query_exists.models import Book
 
+
 def benchmark():
     #Checking for object that exists
     Book.objects.filter(id=1).exists()
@@ -11,9 +12,9 @@ def benchmark():
 if hasattr(Book.objects, 'exists'):
     run_benchmark(
         benchmark,
-        meta = {
+        meta={
             'description': 'A Model.objects.exists() call for both existing and non-existing objects.'
         }
     )
 else:
-    print "SKIP: Django before 1.2 doesn't have QuerySet.exists()"
+    print("SKIP: Django before 1.2 doesn't have QuerySet.exists()")

--- a/djangobench/benchmarks/query_get_or_create/benchmark.py
+++ b/djangobench/benchmarks/query_get_or_create/benchmark.py
@@ -4,9 +4,10 @@ from query_get_or_create.models import Book
 
 counter = itertools.count(1)
 
+
 def benchmark():
-    nextid = counter.next()
-    
+    nextid = next(counter)
+
     # This will do a create ...
     Book.objects.get_or_create(id=nextid, defaults={'title': 'hi'})
     
@@ -15,7 +16,8 @@ def benchmark():
 
 run_benchmark(
     benchmark,
-    meta = {
-        'description': 'A Model.objects.get_or_create() call, both for existing and non-existing objects.',
+    meta={
+        'description': 'A Model.objects.get_or_create() call, both for '
+                       'existing and non-existing objects.',
     }
 )

--- a/djangobench/benchmarks/query_prefetch_related/benchmark.py
+++ b/djangobench/benchmarks/query_prefetch_related/benchmark.py
@@ -2,10 +2,12 @@ from djangobench.utils import run_benchmark
 from django import VERSION
 from query_prefetch_related.models import Book, Author
 
+
 def benchmark():
-    for i in xrange(10):
+    for i in range(10):
         for a in Author.objects.prefetch_related('books'):
             list(a.books.all())
+
 
 def setup():
     for i in range(0, 20):
@@ -22,7 +24,7 @@ else:
     run_benchmark(
         benchmark,
         setup=setup,
-        meta = {
+        meta={
             'description': 'A simple Model.objects.select_related() call.',
         }
     )

--- a/djangobench/benchmarks/query_select_related/benchmark.py
+++ b/djangobench/benchmarks/query_select_related/benchmark.py
@@ -1,13 +1,14 @@
 from djangobench.utils import run_benchmark
 from query_select_related.models import Book
 
+
 def benchmark():
-    for i in xrange(20):
+    for i in range(20):
         list(Book.objects.select_related('author'))
 
 run_benchmark(
     benchmark,
-    meta = {
+    meta={
         'description': 'A simple Model.objects.select_related() call.',
     }
 )

--- a/djangobench/benchmarks/template_render/benchmark.py
+++ b/djangobench/benchmarks/template_render/benchmark.py
@@ -49,8 +49,8 @@ def benchmark_django_gt_13():
 
 run_benchmark(
     benchmark_django_gt_13 if VERSION > (1, 3) else benchmark_django_lte_13,
-    syncdb = False,
-    meta = {
+    syncdb=False,
+    meta={
         'description': ('Render a somewhat complex, fairly typical template '
                         '(including inheritance, reverse URL resolution, etc.).'),
     }

--- a/djangobench/benchmarks/template_render/settings.py
+++ b/djangobench/benchmarks/template_render/settings.py
@@ -1,6 +1,9 @@
-from unipath import FSPath as Path
+import os
+
 from djangobench.base_settings import *
 
 INSTALLED_APPS = ['template_render']
-TEMPLATE_DIRS = [Path(__file__).parent.child('templates').absolute()]
+TEMPLATE_DIRS = (
+    os.path.abspath(os.path.join(os.path.dirname(__file__), 'templates')),
+)
 ROOT_URLCONF = 'template_render.urls'

--- a/djangobench/main.py
+++ b/djangobench/main.py
@@ -4,6 +4,7 @@
 Run us some Django benchmarks.
 """
 import logging
+import os
 
 import subprocess
 import argparse
@@ -11,109 +12,123 @@ import email
 import simplejson
 import sys
 from djangobench import perf
-from unipath import DIRS, FSPath as Path
 
 __version__ = '0.10'
 
-DEFAULT_BENCHMARK_DIR = Path(__file__).parent.child('benchmarks').absolute()
+DEFAULT_BENCHMARK_DIR = os.path.join(os.path.dirname(__file__), 'benchmarks')
 
-def run_benchmarks(control, experiment, benchmark_dir, benchmarks, trials, vcs=None, record_dir=None, profile_dir=None, continue_on_error=False):
+
+def run_benchmarks(control, experiment, benchmark_dir, benchmarks, trials,
+                   vcs=None, record_dir=None, profile_dir=None,
+                   continue_on_error=False):
     if benchmarks:
-        print "Running benchmarks: %s" % " ".join(benchmarks)
+        print("Running benchmarks: %s" % " ".join(benchmarks))
     else:
-        print "Running all benchmarks"
+        print("Running all benchmarks")
 
     if record_dir:
-        record_dir = Path(record_dir).expand().absolute()
-        if not record_dir.exists():
+        record_dir = os.path.abspath(record_dir)
+        if not os.path.isdir(record_dir):
             raise ValueError('Recording directory "%s" does not exist' % record_dir)
-        print "Recording data to '%s'" % record_dir
+        print("Recording data to '%s'" % record_dir)
+    if profile_dir:
+        profile_dir = os.path.abspath(profile_dir)
+        if not os.path.isdir(profile_dir):
+            raise ValueError('Profile directory "%s" does not exist' % profile_dir)
+        print("Recording profile data to '%s'" % profile_dir)
 
     control_label = get_django_version(control, vcs=vcs)
     experiment_label = get_django_version(experiment, vcs=vcs)
     branch_info = "%s branch " % vcs if vcs else ""
-    print "Control: Django %s (in %s%s)" % (control_label, branch_info, control)
-    print "Experiment: Django %s (in %s%s)" % (experiment_label, branch_info, experiment)
-    print
+    print("Control: Django %s (in %s%s)" % (control_label, branch_info, control))
+    print("Experiment: Django %s (in %s%s)" % (experiment_label, branch_info, experiment))
+    print('')
 
     # Calculate the subshell envs that we'll use to execute the
     # benchmarks in.
     if vcs:
         control_env = {
-            'PYTHONPATH': '%s:%s' % (Path.cwd().absolute(), Path(benchmark_dir)),
+            'PYTHONPATH': '%s:%s' % (os.path.abspath(os.getcwd()), benchmark_dir),
         }
         experiment_env = control_env.copy()
     else:
-        control_env = {'PYTHONPATH': '%s:%s' % (Path(control).absolute(), Path(benchmark_dir))}
-        experiment_env = {'PYTHONPATH': '%s:%s' % (Path(experiment).absolute(), Path(benchmark_dir))}
+        control_env = {'PYTHONPATH': '%s:%s' % (os.path.abspath(control), benchmark_dir)}
+        experiment_env = {'PYTHONPATH': '%s:%s' % (os.path.abspath(experiment), benchmark_dir)}
 
     for benchmark in discover_benchmarks(benchmark_dir):
-        if not benchmarks or benchmark.name in benchmarks:
-            print "Running '%s' benchmark ..." % benchmark.name
-            settings_mod = '%s.settings' % benchmark.name
+        if not benchmarks or benchmark in benchmarks:
+            print("Running '%s' benchmark ..." % benchmark)
+            settings_mod = '%s.settings' % benchmark
             control_env['DJANGO_SETTINGS_MODULE'] = settings_mod
             experiment_env['DJANGO_SETTINGS_MODULE'] = settings_mod
             if profile_dir is not None:
-                control_env['DJANGOBENCH_PROFILE_FILE'] = Path(profile_dir, "con-%s" % benchmark.name)
-                experiment_env['DJANGOBENCH_PROFILE_FILE'] = Path(profile_dir, "exp-%s" % benchmark.name)
+                control_env['DJANGOBENCH_PROFILE_FILE'] = os.path.join(profile_dir, "con-%s" % benchmark)
+                experiment_env['DJANGOBENCH_PROFILE_FILE'] = os.path.join(profile_dir, "exp-%s" % benchmark)
             try:
-                if vcs: switch_to_branch(vcs, control)
-                control_data = run_benchmark(benchmark, trials, control_env)
-                if vcs: switch_to_branch(vcs, experiment)
-                experiment_data = run_benchmark(benchmark, trials, experiment_env)
-            except SkipBenchmark, reason:
-                print "Skipped: %s\n" % reason
+                if vcs:
+                    switch_to_branch(vcs, control)
+                control_data = run_benchmark(benchmark, benchmark_dir, trials, control_env)
+                if vcs:
+                    switch_to_branch(vcs, experiment)
+                experiment_data = run_benchmark(benchmark, benchmark_dir, trials, experiment_env)
+            except SkipBenchmark as reason:
+                print("Skipped: %s\n" % reason)
                 continue
-            except RuntimeError, error:
+            except RuntimeError as error:
                 if continue_on_error:
-                    print "Failed: %s\n" % error
+                    print("Failed: %s\n" % error)
                     continue
                 raise
 
             options = argparse.Namespace(
-                track_memory = False,
-                diff_instrumentation = False,
-                benchmark_name = benchmark.name,
-                disable_timelines = True,
-                control_label = control_label,
-                experiment_label = experiment_label,
+                track_memory=False,
+                diff_instrumentation=False,
+                benchmark_name=benchmark,
+                disable_timelines=True,
+                control_label=control_label,
+                experiment_label=experiment_label,
             )
             result = perf.CompareBenchmarkData(control_data, experiment_data, options)
             if record_dir:
                 record_benchmark_results(
-                    dest = record_dir.child('%s.json' % benchmark.name),
-                    name = benchmark.name,
-                    result = result,
-                    control = control_label,
-                    experiment = experiment_label,
-                    control_data = control_data,
-                    experiment_data = experiment_data,
+                    dest=os.path.join(record_dir, '%s.json' % benchmark),
+                    name=benchmark,
+                    result=result,
+                    control=control_label,
+                    experiment=experiment_label,
+                    control_data=control_data,
+                    experiment_data=experiment_data,
                 )
-            print format_benchmark_result(result, len(control_data.runtimes))
-            print
+            print(format_benchmark_result(result, len(control_data.runtimes)))
+            print('')
+
 
 def discover_benchmarks(benchmark_dir):
-    for app in Path(benchmark_dir).listdir(filter=DIRS):
-        if app.child('benchmark.py').exists() and app.child('settings.py').exists():
+    for app in os.listdir(benchmark_dir):
+        if os.path.exists(os.path.join(benchmark_dir, app, 'benchmark.py')) and \
+                os.path.exists(os.path.join(benchmark_dir, app, 'settings.py')):
             yield app
+
 
 def print_benchmarks(benchmark_dir):
     for app in discover_benchmarks(benchmark_dir):
-        print app.name
+        print(app)
+
 
 class SkipBenchmark(Exception):
     pass
 
-def run_benchmark(benchmark, trials, env):
+
+def run_benchmark(benchmark, benchmark_dir, trials, env):
     """
     Similar to perf.MeasureGeneric, but modified a bit for our purposes.
     """
     # Remove Pycs, then call the command once to prime the pump and
     # re-generate fresh ones. This makes sure we're measuring as little of
     # Python's startup time as possible.
-    RemovePycs()
-    command = [sys.executable, '%s/benchmark.py' % benchmark]
-    out, _, _ = perf.CallAndCaptureOutput(command + ['-t', 1], env, track_memory=False, inherit_env=[])
+    remove_pycs()
+    command = [sys.executable, os.path.join(benchmark_dir, benchmark, 'benchmark.py')]
+    out, _, _ = perf.CallAndCaptureOutput(command + ['-t', '1'], env, track_memory=False, inherit_env=[])
     if out.startswith('SKIP:'):
         raise SkipBenchmark(out.replace('SKIP:', '').strip())
 
@@ -124,36 +139,40 @@ def run_benchmark(benchmark, trials, env):
     data_points = [float(line) for line in message.get_payload().splitlines()]
     return perf.RawData(data_points, mem_usage, inst_output=stderr)
 
+
 def record_benchmark_results(dest, **kwargs):
     kwargs['version'] = __version__
     simplejson.dump(kwargs, open(dest, 'w'), default=json_encode_custom)
+
 
 def json_encode_custom(obj):
     if isinstance(obj, perf.RawData):
         return obj.runtimes
     if isinstance(obj, perf.BenchmarkResult):
         return {
-            'min_base'    : obj.min_base,
-            'min_changed' : obj.min_changed,
-            'delta_min'   : obj.delta_min,
-            'avg_base'    : obj.avg_base,
-            'avg_changed' : obj.avg_changed,
-            'delta_avg'   : obj.delta_avg,
-            't_msg'       : obj.t_msg,
-            'std_base'    : obj.std_base,
-            'std_changed' : obj.std_changed,
-            'delta_std'   : obj.delta_std,
+            'min_base': obj.min_base,
+            'min_changed': obj.min_changed,
+            'delta_min': obj.delta_min,
+            'avg_base': obj.avg_base,
+            'avg_changed': obj.avg_changed,
+            'delta_avg': obj.delta_avg,
+            't_msg': obj.t_msg,
+            'std_base': obj.std_base,
+            'std_changed': obj.std_changed,
+            'delta_std': obj.delta_std,
         }
     if isinstance(obj, perf.SimpleBenchmarkResult):
         return {
-            'base_time'    : obj.base_time,
-            'changed_time' : obj.changed_time,
-            'time_delta'   : obj.time_delta,
+            'base_time': obj.base_time,
+            'changed_time': obj.changed_time,
+            'time_delta': obj.time_delta,
         }
     raise TypeError("%r is not JSON serializable" % obj)
 
+
 def supports_color():
     return sys.platform != 'win32' and hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
+
 
 class colorize(object):
     GOOD = INSIGNIFICANT = SIGNIFICANT = BAD = ENDC = ''
@@ -183,6 +202,7 @@ class colorize(object):
     @classmethod
     def bad(cls, text):
         return cls.colorize(cls.BAD, text)
+
 
 def format_benchmark_result(result, num_points):
     if isinstance(result, perf.BenchmarkResult):
@@ -220,17 +240,19 @@ def format_benchmark_result(result, num_points):
     else:
         return str(result)
 
+
 def get_django_version(loc, vcs=None):
     if vcs:
         switch_to_branch(vcs, loc, do_cleanup=True)
-        pythonpath = Path.cwd()
+        pythonpath = os.getcwd()
     else:
-        pythonpath = Path(loc).absolute()
+        pythonpath = os.path.abspath(loc)
     out, err, _ = perf.CallAndCaptureOutput(
-        [sys.executable, '-c' 'import django; print django.get_version()'],
-        env = {'PYTHONPATH': pythonpath}
+        [sys.executable, '-c' 'import django; print(django.get_version())'],
+        env={'PYTHONPATH': pythonpath}
     )
     return out.strip()
+
 
 def switch_to_branch(vcs, branchname, do_cleanup=False):
     if vcs == 'git':
@@ -240,84 +262,87 @@ def switch_to_branch(vcs, branchname, do_cleanup=False):
     else:
         raise ValueError("Sorry, %s isn't supported (yet?)" % vcs)
     if do_cleanup:
-        RemovePycs(vcs=vcs)
+        remove_pycs(vcs=vcs)
     subprocess.check_call(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-def RemovePycs(vcs=None):
+
+def remove_pycs(vcs=None):
     if vcs == 'git':
         cmd = ['git', 'clean', '-fdX']
         subprocess.check_call(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     else:
         perf.RemovePycs()
 
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--control',
-        metavar = 'PATH',
-        default = 'django-control',
-        help = "Path to the Django code tree to use as control."
+        metavar='PATH',
+        default='django-control',
+        help="Path to the Django code tree to use as control."
     )
     parser.add_argument(
         '--experiment',
-        metavar = 'PATH',
-        default = 'django-experiment',
-        help = "Path to the Django version to use as experiment."
+        metavar='PATH',
+        default='django-experiment',
+        help="Path to the Django version to use as experiment."
     )
     parser.add_argument(
         '--vcs',
-        choices = ['git', 'hg', 'none'],
-        default = 'git',
-        help = 'Use a VCS for control/experiment. Makes --control/--experiment specify branches, not paths.'
+        choices=['git', 'hg', 'none'],
+        default='git',
+        help='Use a VCS for control/experiment. Makes --control/--experiment '
+             'specify branches, not paths.'
     )
     parser.add_argument(
         '-t', '--trials',
-        type = int,
-        default = 50,
-        help = 'Number of times to run each benchmark.'
+        type=int,
+        default=50,
+        help='Number of times to run each benchmark.'
     )
     parser.add_argument(
         '-r', '--record',
-        default = None,
-        metavar = 'PATH',
-        help = 'Directory to record detailed output as a series of JSON files.',
+        default=None,
+        metavar='PATH',
+        help='Directory to record detailed output as a series of JSON files.',
     )
-
     parser.add_argument(
         '--benchmark-dir',
-        dest = 'benchmark_dir',
-        metavar = 'PATH',
-        default = DEFAULT_BENCHMARK_DIR,
-        help = ('Directory to inspect for benchmarks. Defaults to the '
-                'benchmarks included with djangobench.'),
+        dest='benchmark_dir',
+        metavar='PATH',
+        default=DEFAULT_BENCHMARK_DIR,
+        help='Directory to inspect for benchmarks. Defaults to the benchmarks '
+             'included with djangobench.',
     )
     parser.add_argument(
         'benchmarks',
-        metavar = 'name',
-        default = None,
-        help = "Benchmarks to be run.  Defaults to all.",
-        nargs = '*'
+        metavar='name',
+        default=None,
+        help="Benchmarks to be run.  Defaults to all.",
+        nargs='*'
     )
     parser.add_argument(
         '-p',
         '--profile-dir',
-        dest = 'profile_dir',
-        default = None,
-        metavar = 'PATH',
-        help = 'Directory to record profiling statistics for the control and experimental run of each benchmark'
+        dest='profile_dir',
+        default=None,
+        metavar='PATH',
+        help='Directory to record profiling statistics for the control and '
+             'experimental run of each benchmark'
     )
     parser.add_argument(
         '--continue-on-error',
-        dest = 'continue_on_error',
-        action = 'store_true',
-        help = 'Continue with the remaining benchmarks if any fail',
+        dest='continue_on_error',
+        action='store_true',
+        help='Continue with the remaining benchmarks if any fail',
     )
     parser.add_argument(
         '-l',
         '--list',
-        dest = 'list_benchmarks',
-        action = 'store_true',
-        help = 'List all available benchmarks and exit.',
+        dest='list_benchmarks',
+        action='store_true',
+        help='List all available benchmarks and exit.',
     )
     parser.add_argument(
         '--log',
@@ -337,15 +362,15 @@ def main():
         print_benchmarks(args.benchmark_dir)
     else:
         run_benchmarks(
-            control = args.control,
-            experiment = args.experiment,
-            benchmark_dir = args.benchmark_dir,
-            benchmarks = args.benchmarks,
-            trials = args.trials,
-            vcs = None if args.vcs == 'none' else args.vcs,
-            record_dir = args.record,
-            profile_dir = args.profile_dir,
-            continue_on_error = args.continue_on_error
+            control=args.control,
+            experiment=args.experiment,
+            benchmark_dir=args.benchmark_dir,
+            benchmarks=args.benchmarks,
+            trials=args.trials,
+            vcs=None if args.vcs == 'none' else args.vcs,
+            record_dir=args.record,
+            profile_dir=args.profile_dir,
+            continue_on_error=args.continue_on_error
         )
 
 if __name__ == '__main__':

--- a/djangobench/utils.py
+++ b/djangobench/utils.py
@@ -63,7 +63,7 @@ def run_benchmark(benchmark, syncdb=True, setup=None, trials=None, handle_argv=T
     if setup:
         setup()
 
-    for x in xrange(trials):
+    for x in range(trials):
         start = time_f()
         profile_file = os.environ.get('DJANGOBENCH_PROFILE_FILE', None)
         if profile_file is not None:
@@ -73,9 +73,10 @@ def run_benchmark(benchmark, syncdb=True, setup=None, trials=None, handle_argv=T
         else:
             benchmark_result = benchmark()
         if benchmark_result is not None:
-            print benchmark_result
+            print(benchmark_result)
         else:
-            print time_f() - start
+            print(time_f() - start)
+
 
 def run_comparison_benchmark(benchmark_a, benchmark_b, syncdb=True, setup=None, trials=None, handle_argv=True, meta={}):
     """
@@ -110,7 +111,7 @@ def run_comparison_benchmark(benchmark_a, benchmark_b, syncdb=True, setup=None, 
     if setup:
         setup()
 
-    for x in xrange(trials):
+    for x in range(trials):
         start_a = time_f()
         result_a = benchmark_a()
         result_a = result_a or time_f() - start_a
@@ -119,11 +120,12 @@ def run_comparison_benchmark(benchmark_a, benchmark_b, syncdb=True, setup=None, 
         result_b = benchmark_b()
         result_b = result_b or time_f() - start_b
 
-        print result_a - result_b
+        print(result_a - result_b)
+
 
 def print_benchmark_header(benchmark, meta):
     if 'title' not in map(str.lower, meta.keys()):
         meta['title'] = inspect.getmodule(benchmark).__name__
     for key, value in meta.items():
-        print '%s: %s' % (key.lower(), value)
-    print
+        print('%s: %s' % (key.lower(), value))
+    print('')

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,23 @@
 import os
 from setuptools import setup, find_packages
 
+
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(
-    name = "djangobench",
-    version = "0.10",
-    description = "A harness and a set of benchmarks for measuring Django's performance over time.",
-    long_description = read('README.rst'),
-    url = 'https://github.com/django/djangobench',
-    license = 'BSD',
-    author = 'Jacob Kaplan-Moss',
-    author_email = 'jacob@jacobian.org',
-    packages = find_packages(),
-    include_package_data = True,
+    name="djangobench",
+    version="0.10",
+    description="A harness and a set of benchmarks for measuring Django's performance over time.",
+    long_description=read('README.rst'),
+    url='https://github.com/django/djangobench',
+    license='BSD',
+    author='Jacob Kaplan-Moss',
+    author_email='jacob@jacobian.org',
+    packages=find_packages(),
+    include_package_data=True,
     zip_safe=False,
-    classifiers = [
+    classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',
         'Framework :: Django',
@@ -24,12 +25,15 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
         'Topic :: Software Development :: Testing',
         'Topic :: System :: Benchmark'
     ],
-    install_requires = ['argparse==1.1', 'Unipath==0.2.1', 'simplejson==2.1.1'],
-
-    entry_points = {
-        'console_scripts': ['djangobench = djangobench.main:main']
+    install_requires=['simplejson==3.3.1'],
+    entry_points={
+        'console_scripts': ['djangobench=djangobench.main:main']
     }
 )


### PR DESCRIPTION
Removed Unipath dependency as it claims to support Python 3, but has an open
issue regarding Python 3 support https://github.com/mikeorr/Unipath/pull/10.

Removed argparse dependency as Python 2.7 and 3.2 included argparse in stdlib.

Furthermore some PEP8 cleanups on the files touched.

Fixes #13
