### PR TITLE
Add benchmark for values() with 10000 rows.

### DIFF
--- a/djangobench/benchmarks/query_values_10000/benchmark.py
+++ b/djangobench/benchmarks/query_values_10000/benchmark.py
@@ -1,0 +1,19 @@
+from djangobench.utils import run_benchmark
+
+
+def setup():
+    global Book
+    from query_values_10000.models import Book
+    Book.objects.bulk_create((
+        Book(title='title')
+        for x in range(10000)
+    ))
+
+def benchmark():
+    global Book
+    list(Book.objects.values('title'))
+
+run_benchmark(
+    benchmark,
+    setup=setup,
+)

--- a/djangobench/benchmarks/query_values_10000/models.py
+++ b/djangobench/benchmarks/query_values_10000/models.py
@@ -1,0 +1,5 @@
+from django.db import models
+
+
+class Book(models.Model):
+    title = models.CharField(max_length=100)

--- a/djangobench/benchmarks/query_values_10000/settings.py
+++ b/djangobench/benchmarks/query_values_10000/settings.py
@@ -1,0 +1,3 @@
+from djangobench.base_settings import *  # NOQA
+
+INSTALLED_APPS = ['query_values_10000']


### PR DESCRIPTION
This benchmark is like `query_values` but `query_values` evaluates queryset only with 10 rows. The results differ significantly.