### PR TITLE
Updated path separator for Windows Compatibility

### DIFF
--- a/djangobench/main.py
+++ b/djangobench/main.py
@@ -49,12 +49,12 @@ def run_benchmarks(control, experiment, benchmark_dir, benchmarks, trials,
     # benchmarks in.
     if vcs:
         control_env = {
-            'PYTHONPATH': '%s:%s' % (os.path.abspath(os.getcwd()), benchmark_dir),
+            'PYTHONPATH': '%s%s%s' % (os.path.abspath(os.getcwd()), os.pathsep, benchmark_dir),
         }
         experiment_env = control_env.copy()
     else:
-        control_env = {'PYTHONPATH': '%s:%s' % (os.path.abspath(control), benchmark_dir)}
-        experiment_env = {'PYTHONPATH': '%s:%s' % (os.path.abspath(experiment), benchmark_dir)}
+        control_env = {'PYTHONPATH': '%s%s%s' % (os.path.abspath(control), os.pathsep, benchmark_dir)}
+        experiment_env = {'PYTHONPATH': '%s%s%s' % (os.path.abspath(experiment), os.pathsep, benchmark_dir)}
 
     for benchmark in discover_benchmarks(benchmark_dir):
         if not benchmarks or benchmark in benchmarks:


### PR DESCRIPTION
I saw a link to this the other day and took a look. I needed this change to get it working on Windows as the path separator is different. https://docs.python.org/3/library/os.html#os.pathsep

It's unclear to me on the current status of this project and if there is any interest in giving it a bit of an update or (and more importantly if it's worth the ROI). 