### PR TITLE
Added Sha-1 to report output

### DIFF
--- a/djangobench/main.py
+++ b/djangobench/main.py
@@ -38,8 +38,8 @@ def run_benchmarks(control, experiment, benchmark_dir, benchmarks, trials,
             raise ValueError('Profile directory "%s" does not exist' % profile_dir)
         print("Recording profile data to '%s'" % profile_dir)
 
-    control_label = get_django_version(control, vcs=vcs)
-    experiment_label = get_django_version(experiment, vcs=vcs)
+    control_label, control_commit = get_django_version(control, vcs=vcs)
+    experiment_label, experiment_commit = get_django_version(experiment, vcs=vcs)
     branch_info = "%s branch " % vcs if vcs else ""
     print("Control: Django %s (in %s%s)" % (control_label, branch_info, control))
     print("Experiment: Django %s (in %s%s)" % (experiment_label, branch_info, experiment))
@@ -100,7 +100,9 @@ def run_benchmarks(control, experiment, benchmark_dir, benchmarks, trials,
                     name=benchmark,
                     result=result,
                     control=control_label,
+                    control_commit=control_commit,
                     experiment=experiment_label,
+                    experiment_commit=experiment_commit,
                     control_data=control_data,
                     experiment_data=experiment_data,
                 )
@@ -257,7 +259,8 @@ def get_django_version(loc, vcs=None):
         [sys.executable, '-c' 'import django; print(django.get_version())'],
         env={'PYTHONPATH': pythonpath}
     )
-    return out.strip()
+    commit_out, commit_err, _ = perf.CallAndCaptureOutput(['git', 'rev-parse', 'HEAD'])
+    return out.strip(), commit_out.strip()
 
 
 def switch_to_branch(vcs, branchname, do_cleanup=False):


### PR DESCRIPTION
Hi @adamchainz hope all is well. 

I've been thinking about this and made some progress. What I have in mind is setting up a GitHub Action on a schedule to run the benchmark suite and store the outputs in a `datasette`.  

I'd like to add the commit hash to the output from djangobench and this pull request proposes this change. The commit hash is needed so we can easily identify which commit caused a performance regression. 

I've already managed to automate a process that creates a datasette of the commit history of Django and is published at [heroku](https://djangobench-tracker.herokuapp.com/django/commits), here is the [source repo](https://github.com/smithdc1/djangobench-tracker). I wanted to do this, so we can provide a description of the commit. It also exposes other data that may be of interest. Simon's existing tools made this fairly straight forward. 
