### PR TITLE
Remove newline char from `t_msg`

### DIFF
--- a/djangobench/main.py
+++ b/djangobench/main.py
@@ -164,7 +164,7 @@ def json_encode_custom(obj):
             'avg_base': obj.avg_base,
             'avg_changed': obj.avg_changed,
             'delta_avg': obj.delta_avg,
-            't_msg': obj.t_msg,
+            't_msg': obj.t_msg.strip(),
             'std_base': obj.std_base,
             'std_changed': obj.std_changed,
             'delta_std': obj.delta_std,


### PR DESCRIPTION
`t_msg` has a new line at the end of the string:

https://github.com/django/djangobench/blob/master/djangobench/perf.py#L964

While fine for the terminal, this isn't required for the json output. 

