### PR TITLE
ORM overhead compared to cursor.execute() benchmark added

### DIFF
--- a/TODO
+++ b/TODO
@@ -2,7 +2,6 @@
 
 * Lots and lots and lots more benchmarks. Some remaining ideas
 
-    * ORM overhead compared to cursor.execute()
     * signal dispatch
     * more datastructures
     * more intensive url resolving and reversing

--- a/djangobench/benchmarks/orm_vs_cursor_exec/benchmark.py
+++ b/djangobench/benchmarks/orm_vs_cursor_exec/benchmark.py
@@ -1,0 +1,32 @@
+from django.db import connection
+
+from djangobench.utils import run_comparison_benchmark
+
+
+def setup():
+    global Book
+    from orm_vs_cursor_exec.models import Book
+    for i in range(0, 300):
+        Book(title=f"book_{i}").save()
+
+def benchmark_orm():
+    global Book
+    from orm_vs_cursor_exec.models import Book
+    Book.objects.all()
+
+
+def benchmark_cursor_exec():
+    cursor = connection.cursor()
+    cursor.execute(
+        "select * from book"
+    )
+    list(cursor.fetchall())
+
+run_comparison_benchmark(
+    benchmark_orm,
+    benchmark_cursor_exec,
+    setup=setup,
+    meta={
+        'description': 'Overhead of ORM compared to cursor.execute()'
+    }
+)

--- a/djangobench/benchmarks/orm_vs_cursor_exec/models.py
+++ b/djangobench/benchmarks/orm_vs_cursor_exec/models.py
@@ -1,0 +1,8 @@
+from django.db import models
+
+
+class Book(models.Model):
+    title = models.CharField(max_length=100)
+
+    class Meta:
+        db_table = "book"

--- a/djangobench/benchmarks/orm_vs_cursor_exec/settings.py
+++ b/djangobench/benchmarks/orm_vs_cursor_exec/settings.py
@@ -1,0 +1,3 @@
+from djangobench.base_settings import *  # NOQA
+
+INSTALLED_APPS = ['orm_vs_cursor_exec']


### PR DESCRIPTION
I also modified the migration behavior in utils.run_comparison_benchmark() similar to utils.run_benchmark().