### PR TITLE
Fix run instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,10 +10,10 @@ Running the benchmarks
 Here's the short version::
 
     mkvirtualenv djangobench
-    pip install -e git://github.com/django/djangobench.git#egg=djangobench
-    git clone git://github.com/django/django.git
+    pip install -e git+https://github.com/django/djangobench.git#egg=djangobench
+    git clone https://github.com/django/django.git
     cd django
-    djangobench --control=1.2 --experiment=master
+    djangobench --control=1.2 --experiment=main
 
 Okay, so what the heck's going on here?
 
@@ -69,7 +69,7 @@ full paths to the corresponding Python executables in ``--control-python`` and
 ``djangobench`` environment setup like above)::
 
     mkvirtualenv djangobench-py3 -p python3
-    pip install -e git://github.com/django/djangobench.git#egg=djangobench
+    pip install -e git+https://github.com/django/djangobench.git#egg=djangobench
     cd django
     djangobench --vcs=none --control=. --experiment=. \
         --control-python=~/.virtualenvs/djangobench/bin/python \


### PR DESCRIPTION
Error when running following current instruction:
```shell
(.venv) vladimirkasatkin@vladimirkasatkin bench311 % pip install -e git://github.com/django/djangobench.git#egg=djangobench

Obtaining djangobench from git+git://github.com/django/djangobench.git#egg=djangobench
  Cloning git://github.com/django/djangobench.git to ./.venv/src/djangobench
  Running command git clone --filter=blob:none --quiet git://github.com/django/djangobench.git /Users/vladimirkasatkin/Developer/bench311/.venv/src/djangobench
  fatal: unable to connect to github.com:
  github.com[0: 140.82.121.4]: errno=Operation timed out
```

After using a proper URL:
```shell
(.venv) vladimirkasatkin@vladimirkasatkin bench311 % pip install -e git+https://github.com/django/djangobench.git#egg=djangobench

Obtaining djangobench from git+https://github.com/django/djangobench.git#egg=djangobench
  Cloning https://github.com/django/djangobench.git to ./.venv/src/djangobench
  Running command git clone --filter=blob:none --quiet https://github.com/django/djangobench.git /Users/vladimirkasatkin/Developer/bench311/.venv/src/djangobench
  Resolved https://github.com/django/djangobench.git to commit 4c88fa81c4d7618604ae51e07c03c23f6734c2e6
  Preparing metadata (setup.py) ... done
Installing collected packages: djangobench
  Running setup.py develop for djangobench
Successfully installed djangobench-0.10
```